### PR TITLE
Install fails with the instruction to use asdf plugin add asdf-alias

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ manager plugin for the [asdf version manager](https://asdf-vm.com).
 ## Install
 
 ```shell
-asdf plugin add asdf-alias
+asdf plugin add alias
 # or
 asdf plugin add https://github.com/andrewthauer/asdf-alias.git
 ```


### PR DESCRIPTION
I was just pointed to this plugin, but the first experience was not the nicest one:

```shell
❯ asdf plugin add asdf-alias
plugin asdf-alias not found in repository
❯ asdf plugin add alias
❯ asdf plugin list --urls --refs
alias                        https://github.com/andrewthauer/asdf-alias.git master b008c47
```

This PR fixes that.